### PR TITLE
Add licensing and vaccination contracts

### DIFF
--- a/contracts/facility-licensing-and-inspections.clar
+++ b/contracts/facility-licensing-and-inspections.clar
@@ -1,0 +1,154 @@
+;; title: facility-licensing-and-inspections
+;; version: 1.0.0
+;; summary: Register facilities, manage license expirations, and record inspection results.
+;; description: Simple, self-contained contract for kennel/daycare facility metadata and inspections. No cross-contract calls or traits.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Constants and errors
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-constant ERR-NOT-FOUND (err u100))
+(define-constant ERR-NOT-AUTHORIZED (err u101))
+(define-constant ERR-ALREADY-REGISTERED (err u102))
+(define-constant ERR-BAD-PARAMS (err u103))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Data vars
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-data-var next-facility-id uint u1)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Data maps
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; facility-id => { owner, name, license-expiry, active, created-at }
+(define-map facilities
+  { id: uint }
+  { owner: principal,
+    name: (string-ascii 64),
+    license-expiry: uint,
+    active: bool,
+    created-at: uint })
+
+;; facility-id => number of inspections (used to generate per-facility inspection ids)
+(define-map facility-inspection-counters
+  { facility-id: uint }
+  { next-inspection-id: uint })
+
+;; keyed by (facility-id, inspection-id)
+(define-map inspections
+  { facility-id: uint, inspection-id: uint }
+  { when: uint,                 ;; epoch seconds (or block-height substitute)
+    score: uint,                ;; arbitrary score u0..u100
+    outcome: (string-ascii 96), ;; short description of result
+    inspector: principal })
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Helpers (private)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-private (only-owner (facility-id uint))
+  (match (map-get? facilities { id: facility-id })
+    facility
+    (if (is-eq (get owner facility) tx-sender)
+        (ok true)
+        ERR-NOT-AUTHORIZED)
+    ERR-NOT-FOUND))
+
+(define-private (get-next-inspection-id (facility-id uint))
+  (let ((row (default-to { next-inspection-id: u1 }
+                         (map-get? facility-inspection-counters { facility-id: facility-id }))))
+    (ok (get next-inspection-id row))))
+
+(define-private (bump-inspection-id (facility-id uint))
+  (let ((row (default-to { next-inspection-id: u1 }
+                         (map-get? facility-inspection-counters { facility-id: facility-id }))))
+    (map-set facility-inspection-counters
+             { facility-id: facility-id }
+             { next-inspection-id: (+ u1 (get next-inspection-id row)) })
+    (ok true)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Public entrypoints
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Register a facility. Returns newly assigned facility id.
+(define-public (register-facility (name (string-ascii 64)) (license-expiry uint) (created-at uint))
+  (begin
+    (asserts! (> (len name) u0) ERR-BAD-PARAMS)
+    (let ((new-id (var-get next-facility-id)))
+      (map-set facilities
+               { id: new-id }
+               { owner: tx-sender,
+                 name: name,
+                 license-expiry: license-expiry,
+                 active: true,
+                 created-at: created-at })
+      (var-set next-facility-id (+ new-id u1))
+      (ok new-id))))
+
+;; Update license-expiry for a facility (owner only)
+(define-public (set-license-expiry (facility-id uint) (license-expiry uint))
+  (begin
+    (asserts! (is-ok (only-owner facility-id)) ERR-NOT-AUTHORIZED)
+    (match (map-get? facilities { id: facility-id })
+      facility
+      (begin
+        (map-set facilities { id: facility-id }
+                 { owner: (get owner facility),
+                   name: (get name facility),
+                   license-expiry: license-expiry,
+                   active: (get active facility),
+                   created-at: (get created-at facility) })
+        (ok true))
+      ERR-NOT-FOUND)))
+
+;; Enable/disable a facility (owner only)
+(define-public (set-active (facility-id uint) (flag bool))
+  (begin
+    (asserts! (is-ok (only-owner facility-id)) ERR-NOT-AUTHORIZED)
+    (match (map-get? facilities { id: facility-id })
+      facility
+      (begin
+        (map-set facilities { id: facility-id }
+                 { owner: (get owner facility),
+                   name: (get name facility),
+                   license-expiry: (get license-expiry facility),
+                   active: flag,
+                   created-at: (get created-at facility) })
+        (ok flag))
+      ERR-NOT-FOUND)))
+
+;; Record an inspection (owner only). Returns inspection-id.
+(define-public (record-inspection (facility-id uint)
+                                 (when uint)
+                                 (score uint)
+                                 (outcome (string-ascii 96)))
+  (begin
+    (asserts! (is-ok (only-owner facility-id)) ERR-NOT-AUTHORIZED)
+    (asserts! (<= score u100) ERR-BAD-PARAMS)
+    (let ((next-id (unwrap! (get-next-inspection-id facility-id) ERR-BAD-PARAMS)))
+      (map-set inspections { facility-id: facility-id, inspection-id: next-id }
+               { when: when, score: score, outcome: outcome, inspector: tx-sender })
+      (unwrap! (bump-inspection-id facility-id) ERR-BAD-PARAMS)
+      (ok next-id))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Read-only entrypoints
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-read-only (get-facility (facility-id uint))
+  (map-get? facilities { id: facility-id }))
+
+(define-read-only (is-facility-active (facility-id uint))
+  (match (map-get? facilities { id: facility-id })
+    data (ok (get active data))
+    (ok false)))
+
+(define-read-only (get-inspection (facility-id uint) (inspection-id uint))
+  (map-get? inspections { facility-id: facility-id, inspection-id: inspection-id }))
+
+(define-read-only (get-next-facility-id)
+  (ok (var-get next-facility-id)))
+
+(define-read-only (get-next-inspection-id-ro (facility-id uint))
+  (unwrap-panic (get-next-inspection-id facility-id)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; End of file
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/contracts/vaccination-verification-portal.clar
+++ b/contracts/vaccination-verification-portal.clar
@@ -1,0 +1,109 @@
+;; title: vaccination-verification-portal
+;; version: 1.0.0
+;; summary: Record vaccination attestations for pets/guests and query their status.
+;; description: Standalone contract with simple ownership model. No cross-contract calls, no traits.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Constants and errors
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-constant ERR-NOT-FOUND (err u200))
+(define-constant ERR-NOT-AUTHORIZED (err u201))
+(define-constant ERR-BAD-PARAMS (err u202))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Data vars
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-data-var next-pet-id uint u1)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Data maps
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; pet-id => { owner, species, name, created-at }
+(define-map pets
+  { id: uint }
+  { owner: principal,
+    species: (string-ascii 24),
+    name: (string-ascii 64),
+    created-at: uint })
+
+;; vaccination keyed by (pet-id, vacc-code)
+(define-map vaccinations
+  { pet-id: uint, vacc-code: (string-ascii 32) }
+  { date: uint,
+    by: principal,
+    revoked: bool,
+    revoke-reason: (optional (string-ascii 64)) })
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Helpers (private)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-private (only-owner (pet-id uint))
+  (match (map-get? pets { id: pet-id })
+    data (if (is-eq (get owner data) tx-sender) (ok true) ERR-NOT-AUTHORIZED)
+    ERR-NOT-FOUND))
+
+(define-private (non-empty (s (string-ascii 64)))
+  (> (len s) u0))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Public entrypoints
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-public (register-pet (species (string-ascii 24)) (name (string-ascii 64)) (created-at uint))
+  (begin
+    (asserts! (non-empty name) ERR-BAD-PARAMS)
+    (asserts! (> (len species) u0) ERR-BAD-PARAMS)
+    (let ((new-id (var-get next-pet-id)))
+      (map-set pets { id: new-id }
+              { owner: tx-sender,
+                species: species,
+                name: name,
+                created-at: created-at })
+      (var-set next-pet-id (+ new-id u1))
+      (ok new-id))))
+
+(define-public (attest-vaccination (pet-id uint)
+                                   (vacc-code (string-ascii 32))
+                                   (date uint))
+  (begin
+    (asserts! (is-ok (only-owner pet-id)) ERR-NOT-AUTHORIZED)
+    (asserts! (> (len vacc-code) u0) ERR-BAD-PARAMS)
+    (map-set vaccinations { pet-id: pet-id, vacc-code: vacc-code }
+             { date: date, by: tx-sender, revoked: false, revoke-reason: none })
+    (ok true)))
+
+(define-public (revoke-vaccination (pet-id uint)
+                                   (vacc-code (string-ascii 32))
+                                   (reason (string-ascii 64)))
+  (begin
+    (asserts! (is-ok (only-owner pet-id)) ERR-NOT-AUTHORIZED)
+    (match (map-get? vaccinations { pet-id: pet-id, vacc-code: vacc-code })
+      v
+      (begin
+        (map-set vaccinations { pet-id: pet-id, vacc-code: vacc-code }
+                 { date: (get date v),
+                   by: (get by v),
+                   revoked: true,
+                   revoke-reason: (some reason) })
+        (ok true))
+      ERR-NOT-FOUND)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Read-only entrypoints
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(define-read-only (get-pet (pet-id uint))
+  (map-get? pets { id: pet-id }))
+
+(define-read-only (get-vaccination (pet-id uint) (vacc-code (string-ascii 32)))
+  (map-get? vaccinations { pet-id: pet-id, vacc-code: vacc-code }))
+
+(define-read-only (has-valid-vaccination (pet-id uint) (vacc-code (string-ascii 32)))
+  (match (map-get? vaccinations { pet-id: pet-id, vacc-code: vacc-code })
+    v (ok (and (not (get revoked v)) (> (get date v) u0)))
+    (ok false)))
+
+(define-read-only (get-next-pet-id)
+  (ok (var-get next-pet-id)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; End of file
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
# Pull Request Details

This PR introduces two independent, self-contained Clarity contracts and supporting documentation for kennel/daycare compliance.

## Changes
- Add facility-licensing-and-inspections contract
  - Facility registration, license expiry updates, enable/disable
  - Per-facility inspections with date, score, and outcome fields
- Add vaccination-verification-portal contract
  - Pet registration with owner principal
  - Vaccination attestations, and revocations with reasons
- Documentation
  - Comprehensive README explaining concept, branch strategy, and usage

## Rationale
- Keep contracts minimal and auditable with straightforward state models
- Avoid cross-contract calls and trait indirection to reduce complexity
- Use explicit inputs for timestamps for deterministic testing

## Testing
- Run `clarinet check` to validate syntax and type-checking
- Add unit tests in `tests/` using the Clarinet JS test harness as needed

## Notes
- Contract state intentionally keeps only essential fields
- Future extensions (not included): pagination helpers, richer access control policies, reporting utilities

## Screenshots/Artifacts
- N/A
